### PR TITLE
Properly patch libs that attempt to load with stack execution enabled on linux.

### DIFF
--- a/fmod-jni-jar/java_api_src/org/fmod/ElfExecStackStripper.java
+++ b/fmod-jni-jar/java_api_src/org/fmod/ElfExecStackStripper.java
@@ -1,0 +1,98 @@
+package org.fmod;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * Internal utility class for removing the executable stack flag (PF_X) from the PT_GNU_STACK
+ * program header of 64-bit ELF binaries.
+ * <p>
+ * Some Linux distributions treat an executable stack as a security risk and prevent
+ * native libraries with this flag from being loaded. This class modifies the ELF header
+ * in-place to clear the PF_X flag from the PT_GNU_STACK segment, if present.
+ * <p>
+ * This is particularly useful when dealing with native libraries (e.g., FMOD) that were
+ * compiled with stack execution enabled by default, but do not actually require it.
+ * <p>
+ * Only 64-bit, little-endian ELF binaries are supported. The input buffer must be backed
+ * by an array and will be modified directly.
+ */
+class ElfExecStackStripper {
+
+	public static boolean isELFFile(ByteBuffer buf) {
+		if (buf.limit() < 16) return false;
+
+		ByteBuffer slice = buf.duplicate(); // safe copy for inspection
+		byte[] eIdent = new byte[4];
+		slice.get(eIdent);
+		return eIdent[0] == 0x7F && eIdent[1] == 'E' && eIdent[2] == 'L' && eIdent[3] == 'F';
+	}
+
+	public static void stripExecStackFlag(ByteBuffer inputBuf) throws UnsatisfiedLinkError {
+		try {
+			// Create a duplicate to avoid modifying caller's buffer state
+			ByteBuffer buf = inputBuf.duplicate().order(ByteOrder.LITTLE_ENDIAN);
+
+			if (buf.get(0) != 0x7F || buf.get(1) != 'E' || buf.get(2) != 'L' || buf.get(3) != 'F') {
+				throw new IOException("Not a valid ELF file.");
+			}
+
+			boolean is64Bit = buf.get(4) == 2;
+			boolean isLittleEndian = buf.get(5) == 1;
+			if (!is64Bit) throw new IOException("Only 64-bit ELF files supported.");
+			if (!isLittleEndian) throw new IOException("Only little-endian ELF files supported.");
+
+			// e_phoff = offset 32, 8 bytes
+			long phoff = getLongLE(buf, 32);
+			int phentsize = getShortLE(buf, 54);
+			int phnum = getShortLE(buf, 56);
+
+			final int PT_GNU_STACK = 0x6474e551;
+			final int PF_X = 0x1;
+
+			for (int i = 0; i < phnum; i++) {
+				int entryOffset = (int) (phoff + i * phentsize);
+				int type = getIntLE(buf, entryOffset);
+
+				if (type == PT_GNU_STACK) {
+					int flags = getIntLE(buf, entryOffset + 4);
+					if ((flags & PF_X) != 0) {
+						int newFlags = flags & ~PF_X;
+						putIntLE(buf, entryOffset + 4, newFlags);
+						System.out.println("Cleared PF_X flag on PT_GNU_STACK.");
+					} else {
+						System.out.println("PF_X flag was already not set.");
+					}
+					return;
+				}
+			}
+
+			throw new IOException("No PT_GNU_STACK segment found.");
+		} catch (Throwable t) {
+			UnsatisfiedLinkError err = new UnsatisfiedLinkError();
+			err.initCause(t);
+			throw err;
+		}
+	}
+
+	// Helper methods
+	private static int getShortLE(ByteBuffer buf, int offset) {
+		return buf.getShort(offset) & 0xFFFF;
+	}
+
+	private static int getIntLE(ByteBuffer buf, int offset) {
+		return buf.getInt(offset);
+	}
+
+	private static long getLongLE(ByteBuffer buf, int offset) {
+		return buf.getLong(offset);
+	}
+
+	private static void putIntLE(ByteBuffer buf, int offset, int value) {
+		buf.putInt(offset, value);
+	}
+
+}

--- a/fmod-jni-jar/java_api_src/org/fmod/FMODLoader.java
+++ b/fmod-jni-jar/java_api_src/org/fmod/FMODLoader.java
@@ -4,6 +4,8 @@ import com.sun.istack.internal.Nullable;
 import com.sun.xml.internal.ws.util.StreamUtils;
 
 import java.io.*;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.zip.CRC32;
 
 /**
@@ -100,10 +102,10 @@ public class FMODLoader {
 	private static boolean loadLibrary(String sharedLibName) {
 		if (sharedLibName == null) return false;
 
-		String sourceCrc = crc(FMODLoader.class.getResourceAsStream(sharedLibName));
-
 		File file;
 		Throwable ex = null;
+		ByteBuffer libBytes;
+		String sourceCrc = crc(getLibBytes(FMODLoader.class.getResourceAsStream(sharedLibName)));
 		
 		// Temp directory with username in path.
 		String user = System.getProperty("user.name");
@@ -179,56 +181,71 @@ public class FMODLoader {
 	}
 
 	/**
-	 * Returns a CRC of the remaining bytes in the stream.
+	 * Returns a CRC of the remaining bytes in the buffer.
+	 *
+	 * The input buffer will remain unchanged.
 	 */
-	public static String crc(InputStream input) {
+	public static String crc(ByteBuffer input) {
 		if (input == null) return "" + System.nanoTime(); // fallback
 		CRC32 crc = new CRC32();
-		byte[] buffer = new byte[4096];
+
+		ByteBuffer buf = input.slice(); //so we don't modify the underlying buffer
+		byte[] temp = new byte[4096];
+		while (buf.hasRemaining()) {
+			int length = Math.min(buf.remaining(), temp.length);
+			buf.get(temp, 0, length);
+			crc.update(temp, 0, length);
+		}
+
+		return Long.toString(crc.getValue());
+	}
+
+	private static ByteBuffer getLibBytes(InputStream stream) {
+		if (stream == null) throw new NullPointerException("Resource stream is null");
+		final int bufferSize = 4096; //4kb buffer
+		byte[] buffer = new byte[bufferSize];
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+		int bytesRead;
 		try {
-			while (true) {
-				int length = input.read(buffer);
-				if (length == -1) break;
-				crc.update(buffer, 0, length);
-			}
-		} catch (Exception ex) {
-			try {
-				input.close();
-			} catch (Exception ignored) {
+			while ((bytesRead = stream.read(buffer)) != -1) {
+				out.write(buffer, 0, bytesRead);
 			}
 		}
-		return Long.toString(crc.getValue());
+		catch(IOException e) {
+			throw new RuntimeException(e);
+		}
+
+		return ByteBuffer.wrap(out.toByteArray());
 	}
 
 	private static String extractLibrary(String sharedLibName, String srcCrc, File nativeFile) {
 		String extractedCrc = null;
-		if (nativeFile.exists()) {
+		ByteBuffer libBytes = null;
+		if(nativeFile.exists()) {
 			try {
-				extractedCrc = crc(new FileInputStream(nativeFile));
+				libBytes = getLibBytes(new FileInputStream(nativeFile));
+				if(ElfExecStackStripper.isELFFile(libBytes)) {
+					ElfExecStackStripper.stripExecStackFlag(libBytes);
+				}
+				extractedCrc = crc(libBytes);
 			} catch (FileNotFoundException ignored) {
+
 			}
 		}
 
 		if (extractedCrc == null || !extractedCrc.equals(srcCrc)) {
-			
-			InputStream input = null;
+
 			FileOutputStream output = null;
 			try {
-				// Extract native from classpath to temp dir.
-				input = FMODLoader.class.getResourceAsStream(sharedLibName);
-				if (input == null) return null;
+				// Extract native from buffer to temp dir
+				if (libBytes == null) return null;
 				nativeFile.getParentFile().mkdirs();
 				output = new FileOutputStream(nativeFile);
-				byte[] buffer = new byte[4096];
-				while (true) {
-					int length = input.read(buffer);
-					if (length == -1) break;
-					output.write(buffer, 0, length);
-				}
+				output.write(libBytes.array());
 			} catch (IOException ex) {
 				throw new RuntimeException(ex);
 			} finally {
-				closeQuietly(input);
 				closeQuietly(output);
 			}
 		}


### PR DESCRIPTION
This is a second attempt at addressing the exec stack flag issue. See https://github.com/NateAustin/fmod-jni/pull/5. The previous fix introduced a bug where native libraries would not be extracted if they hadn’t already been extracted in a prior run.

Mac and Android are untested. It properly fixes the issue in Bazzite, and I didn't experience any issues on Windows 10 or Ubuntu.
I still recommend additional testing before putting into production.

Some Linux distributions treat an executable stack as a security risk and prevent native libraries marked with this flag from being loaded. This change modifies the ELF header in-place at load time to clear the executable permission (`PF_X`) from the `PT_GNU_STACK` segment, if present, allowing the library to load without requiring an executable stack.

Tests:


- [ ] Windows 11, Wildermyth, Fresh Download
- [ ] Windows 11, Wildermyth, Pre-Existing Game
- [ ] Windows 11, Wildermyth, Pre-Existing Game with temporary libraries manually deleted
- [x] Windows 10, Wildermyth, Fresh Download
- [x] Windows 10, Wildermyth, Pre-Existing Game
- [x] Windows 10, Wildermyth, Pre-Existing Game with temporary libraries manually deleted
- [x] Ubuntu 24.04, Wildermyth, Fresh Download
- [x] Ubuntu 24.04, Wildermyth, Pre-Existing Game
- [x] Ubuntu 24.04, Wildermyth, Pre-Existing Game with temporary libraries manually deleted
- [x] Bazzite 42, Wildermyth, Fresh Download
- [x] Bazzite 42, Wildermyth, Pre-Existing Game
- [x] Bazzite 42, Wildermyth, Pre-Existing Game with temporary libraries manually deleted
- [ ] Mac, Wildermyth, Fresh Download
- [ ] Mac, Wildermyth, Pre-Existing Game
- [ ] Mac, Wildermyth, Pre-Existing Game with temporary libraries manually deleted
- [ ] Android?

Fixes NateAustin/fmod-jni#4